### PR TITLE
Updated /users/self api endpoint to /users?profile=true

### DIFF
--- a/acceptance/new-user/join-button-signup.test.js
+++ b/acceptance/new-user/join-button-signup.test.js
@@ -23,7 +23,7 @@ describe("Navigation of Join with incomplete details", () => {
   test("Join button navigation", async () => {
     await page.setRequestInterception(true);
     page.on("request", (request) => {
-      if (request.url().endsWith("/users/self") && request.method() === "GET") {
+      if (request.url().endsWith("/users?profile=true") && request.method() === "GET") {
         request.respond({
           headers: {
             "Access-Control-Allow-Credentials": true,

--- a/acceptance/new-user/join-button.test.js
+++ b/acceptance/new-user/join-button.test.js
@@ -17,7 +17,7 @@ function confirmAlerts() {
 /* check status*/
 async function checkResponse() {
   await page.on("response", (response) => {
-    if (response.url().endsWith("/users/self")) {
+    if (response.url().endsWith("/users?profile=true")) {
           delay(2000)
           expect(response.status()).toBe(401);
           expect(page.url().endsWith("/join"));

--- a/acceptance/new-user/sign-up.test.js
+++ b/acceptance/new-user/sign-up.test.js
@@ -35,7 +35,7 @@ describe("New user navigates in the page", () => {
   test("New user sees a sign up page", async () => {
     await page.goto(HOME_PAGE);
 
-    await page.waitForResponse((res) => res.url().endsWith("/users/self"));
+    await page.waitForResponse((res) => res.url().endsWith("/users?profile=true"));
     await page.waitForSelector("button.login-btn-text");
 
     await Promise.all([

--- a/constants/urls.js
+++ b/constants/urls.js
@@ -6,7 +6,7 @@ const HOME_PAGE = `${WWW_HOST}`;
 const SIGN_UP_PAGE = `${MY_HOST}/signup`;
 const JOIN = `${WWW_HOST}/?join=true`
 
-const SELF_USER_API = `${API_HOST}/users/self`;
+const SELF_USER_API = `${API_HOST}/users?profile=true`;
 
 module.exports = {
     HOME_PAGE,


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 07 Dec 2024
<!--Developer Name Here-->
Developer Name: Hariom Vashista

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
Fixes: Real-Dev-Squad/todo-action-items#255 repo#11
## Description

<!--Description of the changes made in this PR-->
The api endpoint which is being checked has been update from /users/self to /users?profile=true
### Documentation Updated?

- [ ] Yes
- [X] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [X] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [X] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [X] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [Y] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
The tests have been failing before making the changes. For example one of the errors was as shown below:
![Screenshot 2024-12-07 181033](https://github.com/user-attachments/assets/f734713b-c99c-41f5-b162-89621eefb043)
To check the error I went to the URL stored in JOIN variable from an incognito tab (as i am already signed in using RDS) and i didn't find any button or element with .btn-join class. So i have made the changes since those aren't the reasons for the error according to my knowledge/